### PR TITLE
Make sure the Xcode autocompleten returns the correct block with it's pa...

### DIFF
--- a/UIActionSheet+Blocks.h
+++ b/UIActionSheet+Blocks.h
@@ -29,8 +29,8 @@
 +(UIActionSheet *)presentOnView: (UIView *)view
                       withTitle: (NSString *)title
                    otherButtons: (NSArray *)otherStrings
-                       onCancel: (void (^)(UIActionSheet *))cancelBlock
-                onClickedButton: (void (^)(UIActionSheet *, NSUInteger))clickBlock;
+                       onCancel: (void (^)(UIActionSheet *sheet))cancelBlock
+                onClickedButton: (void (^)(UIActionSheet *sheet, NSUInteger buttonIndex))clickBlock;
 
 /**
  Present a UIActionSheet on a specific view
@@ -51,7 +51,7 @@
                    cancelButton: (NSString *)cancelString
               destructiveButton: (NSString *)destructiveString
                    otherButtons: (NSArray *)otherStrings
-                       onCancel: (void (^)(UIActionSheet *))cancelBlock
-                  onDestructive: (void (^)(UIActionSheet *))destroyBlock
-                onClickedButton: (void (^)(UIActionSheet *, NSUInteger))clickBlock;
+                       onCancel: (void (^)(UIActionSheet *sheet))cancelBlock
+                  onDestructive: (void (^)(UIActionSheet *sheet))destroyBlock
+                onClickedButton: (void (^)(UIActionSheet *sheet, NSUInteger buttonIndex))clickBlock;
 @end

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -16,8 +16,8 @@ static void (^__destroyBlock)(UIActionSheet *sheet);
 +(UIActionSheet *)presentOnView:(UIView *)view
                       withTitle:(NSString *)title
                    otherButtons:(NSArray *)otherStrings
-                       onCancel:(void (^)(UIActionSheet *))cancelBlock
-                onClickedButton:(void (^)(UIActionSheet *, NSUInteger))clickBlock{
+                       onCancel:(void (^)(UIActionSheet *sheet))cancelBlock
+                onClickedButton:(void (^)(UIActionSheet *sheet, NSUInteger buttonIndex))clickBlock{
     
     return [self presentOnView:view
                      withTitle:title
@@ -34,9 +34,9 @@ static void (^__destroyBlock)(UIActionSheet *sheet);
                    cancelButton: (NSString *)cancelString
               destructiveButton: (NSString *)destructiveString
                    otherButtons: (NSArray *)otherStrings
-                       onCancel: (void (^)(UIActionSheet *))cancelBlock
-                  onDestructive: (void (^)(UIActionSheet *))destroyBlock
-                onClickedButton: (void (^)(UIActionSheet *, NSUInteger))clickBlock{
+                       onCancel: (void (^)(UIActionSheet *sheet))cancelBlock
+                  onDestructive: (void (^)(UIActionSheet *sheet))destroyBlock
+                onClickedButton: (void (^)(UIActionSheet *sheet, NSUInteger buttonIndex))clickBlock{
     __cancelBlock           = cancelBlock;
     __clickedBlock          = clickBlock;
     __destroyBlock          = destroyBlock;


### PR DESCRIPTION
```
[UIActionSheet presentOnView:self.view.window withTitle:NSLocalizedString(@"Validate flight", @"Validate flight") cancelButton:NSLocalizedString(@"Cancel", @"Cancel") destructiveButton:NSLocalizedString(@"Invalid", @"Invalid") otherButtons:@[NSLocalizedString(@"Valid", @"Valid")] onCancel:^(UIActionSheet *) {
    NSLog(@"cancel");
} onDestructive:^(UIActionSheet *) {
    NSLog(@"invalid");
} onClickedButton:^(UIActionSheet *, NSUInteger) {
    NSLog(@"invalid");
}];
```

should return

```
[UIActionSheet presentOnView:self.view.window withTitle:NSLocalizedString(@"Validate flight", @"Validate flight") cancelButton:NSLocalizedString(@"Cancel", @"Cancel") destructiveButton:NSLocalizedString(@"Invalid", @"Invalid") otherButtons:@[NSLocalizedString(@"Valid", @"Valid")] onCancel:^(UIActionSheet *sheet) {
    NSLog(@"cancel");
} onDestructive:^(UIActionSheet *sheet) {
    NSLog(@"invalid");
} onClickedButton:^(UIActionSheet *sheet, NSUInteger buttonIndex) {
    NSLog(@"invalid");
}];
```
